### PR TITLE
Add interview scheduled event

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -108,3 +108,21 @@ def import_cv_reviewed(greenhouse_cursor, canonical_session):
         )
 
     canonical_session.commit()
+
+
+def interview_scheduled(greenhouse_cursor, canonical_session):
+    greenhouse_cursor.execute(
+        "SELECT jp.job_id, a.candidate_id, si.scheduled_at FROM scheduled_interviews si JOIN applications a ON a.id = si.application_id JOIN job_posts jp ON a.job_post_id = jp.id"
+    )
+
+    for interview_scheduled in greenhouse_cursor.fetchall():
+        canonical_session.add(
+            Event(
+                candidate_id=interview_scheduled[1],
+                job_id=interview_scheduled[0],
+                date=interview_scheduled[2],
+                type="interview_scheduled",
+            )
+        )
+
+    canonical_session.commit()

--- a/main.py
+++ b/main.py
@@ -11,7 +11,8 @@ from functions import (
     import_candidate_rejections,
     import_candidate_hired,
     import_employees,
-    import_cv_reviewed
+    import_cv_reviewed,
+    interview_scheduled,
 ) 
 
 
@@ -33,6 +34,7 @@ import_candidate_applications(greenhouse_cursor, session)
 import_candidate_rejections(greenhouse_cursor, session)
 import_candidate_hired(greenhouse_cursor, session)
 import_cv_reviewed(greenhouse_cursor, session)
+interview_scheduled(greenhouse_cursor, session)
 
 # Close connection
 greenhouse_connection.close()

--- a/models.py
+++ b/models.py
@@ -53,7 +53,7 @@ class Event(Base):
             "cv_reviewed",
             "scorecard_added",
             "stage_moved",
-            "interview_schedule",
+            "interview_scheduled",
             "participated_interview",
             "hired",
             "rejected",


### PR DESCRIPTION
# Done

Add CV reviewed event

# QA

- `dotrun`
- Make sure that the `interview_scheduled` event was well added
- `SELECT * FROM events  WHERE type='interview_scheduled'`

Fixes https://github.com/canonical-web-and-design/workplace-engineering-squad/issues/28

