### PR TITLE
Add hiring leads to jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .venv
 .env.local
 __pycache__/
+hiring_leads.csv

--- a/functions.py
+++ b/functions.py
@@ -1,4 +1,5 @@
 from models import Candidate, Employee, Event, Job
+import csv
 
 
 def import_employees(greenhouse_cursor, canonical_session):
@@ -18,8 +19,39 @@ def get_jobs(greenhouse_cursor, canonical_session):
     greenhouse_cursor.execute("SELECT id, name, opened_at FROM jobs")
 
     for job in greenhouse_cursor.fetchall():
-        j = Job(id=job[0], name=job[1], status="open", opened_at=job[2])
-        canonical_session.add(j)
+        with open("hiring_leads.csv", "r") as csvfile:
+            hiring_leads = csv.reader(csvfile, skipinitialspace=True)
+            j = None
+            for hiring_lead in hiring_leads:
+                if hiring_lead[1] == str(job[0]) and hiring_lead[3]:
+                    # in case there are more than one, then skip
+                    try:
+                        e = (
+                            canonical_session.query(Employee)
+                            .filter(Employee.full_name == hiring_lead[3])
+                            .one_or_none()
+                        )
+                        j = Job(
+                            id=job[0],
+                            name=job[1],
+                            status="open",
+                            opened_at=job[2],
+                            hiring_lead=e.id,
+                        )
+                        canonical_session.add(j)
+                    except:
+                        pass
+                    break
+
+            # for history we keep the jobs without hiring leads
+            if not j:
+                j = Job(
+                    id=job[0],
+                    name=job[1],
+                    status="open",
+                    opened_at=job[2]
+                )
+                canonical_session.add(j)
 
     canonical_session.commit()
 
@@ -41,7 +73,7 @@ def add_new_candidates(greenhouse_cursor, canonical_session):
 
 def import_candidate_applications(greenhouse_cursor, canonical_session):
     greenhouse_cursor.execute(
-        f"SELECT a.applied_at, a.candidate_id ,jp.job_id FROM applications a join job_posts jp on a.job_post_id = jp.id"
+        f"SELECT a.applied_at, a.candidate_id, jp.job_id FROM applications a join job_posts jp on a.job_post_id = jp.id"
     )
     for application in greenhouse_cursor.fetchall():
         e = Event(

--- a/functions.py
+++ b/functions.py
@@ -15,43 +15,19 @@ def import_employees(greenhouse_cursor, canonical_session):
     canonical_session.commit()
 
 
-def get_jobs(greenhouse_cursor, canonical_session):
+def get_jobs(greenhouse_cursor, canonical_session, hiring_leads):
     greenhouse_cursor.execute("SELECT id, name, opened_at FROM jobs")
 
     for job in greenhouse_cursor.fetchall():
-        with open("hiring_leads.csv", "r") as csvfile:
-            hiring_leads = csv.reader(csvfile, skipinitialspace=True)
-            j = None
-            for hiring_lead in hiring_leads:
-                if hiring_lead[1] == str(job[0]) and hiring_lead[3]:
-                    # in case there are more than one, then skip
-                    try:
-                        e = (
-                            canonical_session.query(Employee)
-                            .filter(Employee.full_name == hiring_lead[3])
-                            .one_or_none()
-                        )
-                        j = Job(
-                            id=job[0],
-                            name=job[1],
-                            status="open",
-                            opened_at=job[2],
-                            hiring_lead=e.id,
-                        )
-                        canonical_session.add(j)
-                    except:
-                        pass
-                    break
-
-            # for history we keep the jobs without hiring leads
-            if not j:
-                j = Job(
-                    id=job[0],
-                    name=job[1],
-                    status="open",
-                    opened_at=job[2]
-                )
-                canonical_session.add(j)
+        canonical_session.add(
+            Job(
+                id=job[0],
+                name=job[1],
+                status="open",
+                opened_at=job[2],
+                hiring_lead=hiring_leads.get(job[0]),
+            )
+        )
 
     canonical_session.commit()
 

--- a/main.py
+++ b/main.py
@@ -1,9 +1,10 @@
+import csv
 import os
 import psycopg2
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine
 
-from models import Base
+from models import Base, Employee
 from functions import (
     add_new_candidates,
     get_jobs,
@@ -29,9 +30,27 @@ Base.metadata.create_all(engine)
 Session = sessionmaker(bind=engine)
 session = Session()
 
-# Run functions to fill the database
+
 import_employees(greenhouse_cursor, session)
-get_jobs(greenhouse_cursor, session)
+
+hiring_leads = {}
+with open("hiring_leads.csv", "r") as csvfile:
+    reader = csv.DictReader(csvfile, skipinitialspace=True)
+    for row in reader:
+        if not row["Primary Recruiter"]:
+            continue
+
+        try:
+            employee = (
+                session.query(Employee)
+                .filter(Employee.full_name == row["Primary Recruiter"])
+                .one_or_none()
+            )
+            hiring_leads[int(row["Job ID"])] = employee.id
+        except:
+            continue
+
+get_jobs(greenhouse_cursor, session, hiring_leads)
 add_new_candidates(greenhouse_cursor, session)
 import_candidate_applications(greenhouse_cursor, session)
 import_candidate_rejections(greenhouse_cursor, session)

--- a/models.py
+++ b/models.py
@@ -39,6 +39,7 @@ class Job(Base):
     status = Column(String)
     opened_at = Column(DateTime)
     closed_at = Column(DateTime)
+    hiring_lead = Column(Integer, ForeignKey("employees.id"))
 
 
 class Event(Base):


### PR DESCRIPTION
# Done

Add hiring leads to each jobs. This is based on a sheet from Peter with the job id and the job name

# QA

- Create file: `hiring_leads.csv`
-  Add the data that toto shared with you
- `dotrun`
- Make sure some jobs have a hiring lead and some don't
- 
https://github.com/canonical-web-and-design/workplace-engineering-squad/issues/33