### PR TITLE
Drop all tables on migration

### DIFF
--- a/webapp/database.py
+++ b/webapp/database.py
@@ -13,6 +13,19 @@ greenhouse_connection = lambda: psycopg2.connect(
 
 
 engine = create_engine(os.getenv("CANONICAL_DATABASE_URL"))
-Base.metadata.create_all(engine)
-Session = sessionmaker(bind=engine)
-db_session = Session()
+db_session = None
+
+
+def create_session():
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def drop_all():
+    Base.metadata.drop_all(engine)
+    global db_session
+    db_session = create_session()
+
+
+db_session = create_session()

--- a/webapp/migrate.py
+++ b/webapp/migrate.py
@@ -1,7 +1,7 @@
 import csv
 import os
 
-from webapp.database import greenhouse_connection, db_session
+from webapp.database import greenhouse_connection, db_session, drop_all
 from webapp.functions import (
     add_new_candidates,
     get_jobs,
@@ -21,6 +21,7 @@ from webapp.models import Employee
 with greenhouse_connection() as connection:
     greenhouse_cursor = connection.cursor()
 
+    drop_all()
     import_employees(greenhouse_cursor, db_session)
 
     hiring_leads = {}


### PR DESCRIPTION
# Summary

Fixes https://github.com/canonical-web-and-design/greenhouse-exporter/issues/13
We are dropping the table and repopulating on each migration. Instead of manually dropping the tables, here is a script that will drop the tables on each migration and repopulate them.

# QA

- `dotrun exec yarn run migrate`
- rerun the same command, it shouldn't fail
- `dotrun`
- Make sure the board is still working
- Make sure the db is still filled with data.