### PR TITLE
Support debug user for development.

### DIFF
--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -1,0 +1,5 @@
+import os
+
+
+DEBUG = os.getenv("FLASK_DEBUG", "false").lower() == "true"
+DEBUG_USER_EMAIL = os.getenv("DEBUG_USER_EMAIL")

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -4,6 +4,8 @@ import flask
 from django_openid_auth.teams import TeamsRequest, TeamsResponse
 from flask_openid import OpenID
 
+from webapp.settings import DEBUG, DEBUG_USER_EMAIL
+
 
 SSO_LOGIN_URL = "https://login.ubuntu.com"
 SSO_TEAM = "canonical-content-people"
@@ -34,6 +36,9 @@ def init_sso(app):
             "identity_url": resp.identity_url,
             "email": resp.email,
         }
+
+        if DEBUG and DEBUG_USER_EMAIL:
+            flask.session["openid"]["email"] = DEBUG_USER_EMAIL
 
         return flask.redirect(open_id.get_next_url())
 


### PR DESCRIPTION
## Done

Add `DEBUG_USER_EMAIL` to allow logging in as a specific user in development.

## QA

- Run server as Peter: `dotrun --env DEBUG_USER_EMAIL=peter.mahnke@canonical.com`
- Go to http://localhost:8501/login
  - Verify that the dashboard is populated with data

## Issue

Fixes https://github.com/canonical-web-and-design/greenhouse-exporter/issues/39