### PR TITLE
Add workload table

### DIFF
--- a/static/js/components/Dashboard.tsx
+++ b/static/js/components/Dashboard.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Strip } from "@canonical/react-components";
 import { InterviewParticipation } from "./InterviewParticipation";
 import { JobsDetails } from "./JobsDetails";
+import { Workload } from "./Workload";
 
 export const Dashboard: React.FC<any> = () => {
   return (
@@ -12,6 +13,7 @@ export const Dashboard: React.FC<any> = () => {
         </Strip>
         <JobsDetails />
         <InterviewParticipation />
+        <Workload />
       </main>
     </div>
   );

--- a/static/js/components/Dashboard.tsx
+++ b/static/js/components/Dashboard.tsx
@@ -8,7 +8,7 @@ export const Dashboard: React.FC<any> = () => {
   return (
     <div className="l-application">
       <main className="l-main">
-        <Strip>
+        <Strip shallow={true}>
           <h1>Hiring Dashboard</h1>
         </Strip>
         <JobsDetails />

--- a/static/js/components/InterviewParticipation.tsx
+++ b/static/js/components/InterviewParticipation.tsx
@@ -3,17 +3,26 @@ import { MainTable, Strip } from "@canonical/react-components";
 
 export const InterviewParticipation: React.FC<any> = () => {
   const [interviews, setInterviews] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const getInterviews = async () => {
-      const response = await fetch("/api/interviews");
-      setInterviews(await response.json());
+      try {
+        const response = await fetch("/api/interviews");
+        if (response.status === 200) {
+          setInterviews(await response.json());
+        }
+      } catch (error) {
+        console.error("Error fetching endpoint /api/interviews: ", error);
+      } finally {
+        setIsLoading(false);
+      }
     };
     getInterviews();
   }, []);
 
   return (
-    <Strip type="light">
+    <Strip type="light" shallow={true}>
       <h2>Interview participation</h2>
       <MainTable
         headers={[
@@ -41,7 +50,14 @@ export const InterviewParticipation: React.FC<any> = () => {
           }
         )}
         sortable
-        emptyStateMsg={<i className="p-icon--spinner u-animation--spin"></i>}
+        paginate={10}
+        emptyStateMsg={
+          isLoading ? (
+            <i className="p-icon--spinner u-animation--spin"></i>
+          ) : (
+            <i>No data could be fetched</i>
+          )
+        }
       />
     </Strip>
   );

--- a/static/js/components/JobsDetails.tsx
+++ b/static/js/components/JobsDetails.tsx
@@ -3,17 +3,26 @@ import { MainTable, Strip } from "@canonical/react-components";
 
 export const JobsDetails: React.FC<any> = () => {
   const [jobs, setJobs] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const getJobs = async () => {
-      const response = await fetch("/api/jobs");
-      setJobs(await response.json());
+      try {
+        const response = await fetch("/api/jobs");
+        if (response.status === 200) {
+          setJobs(await response.json());
+        }
+      } catch (error) {
+        console.error("Error fetching endpoint /api/jobs: ", error);
+      } finally {
+        setIsLoading(false);
+      }
     };
     getJobs();
   }, []);
 
   return (
-    <Strip type="light">
+    <Strip type="light" shallow={true}>
       <h2>Jobs details</h2>
       <MainTable
         headers={[
@@ -27,7 +36,14 @@ export const JobsDetails: React.FC<any> = () => {
           };
         })}
         sortable
-        emptyStateMsg={<i className="p-icon--spinner u-animation--spin"></i>}
+        paginate={10}
+        emptyStateMsg={
+          isLoading ? (
+            <i className="p-icon--spinner u-animation--spin"></i>
+          ) : (
+            <i>No data could be fetched</i>
+          )
+        }
       />
     </Strip>
   );

--- a/static/js/components/Workload.tsx
+++ b/static/js/components/Workload.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from "react";
+import { MainTable, Strip } from "@canonical/react-components";
+
+export const Workload: React.FC<{}> = () => {
+  const [workload, setWorkload] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const getWorkload = async () => {
+      const response = await fetch("/api/workload");
+      setWorkload(await response.json());
+      setIsLoading(false);
+    };
+    getWorkload();
+  }, []);
+
+  return (
+    <Strip type="light">
+      <h2>Workload</h2>
+      <MainTable
+        headers={[
+          { content: "Employee", sortKey: "employee" },
+          { content: "Type", sortKey: "type" },
+          { content: "Date", sortKey: "date" },
+          { content: "Estimated duration", sortKey: "estimated_duration" },
+          { content: "Status", sortKey: "status" },
+        ]}
+        rows={workload.map(
+          ({ employee, type, date, estimated_duration, status }) => {
+            return {
+              columns: [
+                { content: employee },
+                { content: type },
+                { content: date },
+                { content: estimated_duration },
+                { content: status },
+              ],
+              sortData: {
+                employee: employee,
+                type: type,
+                date: new Date(date),
+                estimated_duration: estimated_duration,
+                status: status,
+              },
+            };
+          }
+        )}
+        sortable
+        emptyStateMsg={
+          isLoading ? (
+            <i className="p-icon--spinner u-animation--spin"></i>
+          ) : (
+            "No data"
+          )
+        }
+      />
+    </Strip>
+  );
+};

--- a/static/js/components/Workload.tsx
+++ b/static/js/components/Workload.tsx
@@ -1,21 +1,28 @@
 import React, { useEffect, useState } from "react";
 import { MainTable, Strip } from "@canonical/react-components";
 
-export const Workload: React.FC<{}> = () => {
+export const Workload: React.FC<any> = () => {
   const [workload, setWorkload] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const getWorkload = async () => {
-      const response = await fetch("/api/workload");
-      setWorkload(await response.json());
-      setIsLoading(false);
+      try {
+        const response = await fetch("/api/workload");
+        if (response.status === 200) {
+          setWorkload(await response.json());
+        }
+      } catch (error) {
+        console.error("Error fetching endpoint /api/workload: ", error);
+      } finally {
+        setIsLoading(false);
+      }
     };
     getWorkload();
   }, []);
 
   return (
-    <Strip type="light">
+    <Strip type="light" shallow={true}>
       <h2>Workload</h2>
       <MainTable
         headers={[
@@ -46,11 +53,12 @@ export const Workload: React.FC<{}> = () => {
           }
         )}
         sortable
+        paginate={10}
         emptyStateMsg={
           isLoading ? (
             <i className="p-icon--spinner u-animation--spin"></i>
           ) : (
-            "No data"
+            <i>No data could be fetched</i>
           )
         }
       />

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -117,8 +117,10 @@ def api_workload():
                     "employee": row[1],
                     "type": row[2],
                     "date": row[3],
-                    "estimated_duration": round((row[4]-row[3]).total_seconds()/60),
-                    "status": row[5]
+                    "estimated_duration": round(
+                        (row[4] - row[3]).total_seconds() / 60
+                    ),
+                    "status": row[5],
                 }
             )
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -107,7 +107,7 @@ def api_workload():
                     JOIN interviews i2 on si.interview_id = i2.id
                 WHERE u.email= %s
                 ORDER BY si.ends_at DESC;""",
-            ('thomas.bille@canonical.com',),
+            (flask.session["openid"]["email"],),
         )
 
         workload = []


### PR DESCRIPTION
## Done

Fetch data from `/api/workload` and display in a table.

Depends on https://github.com/canonical-web-and-design/greenhouse-exporter/pull/43

## QA

- `dotrun --env DEBUG_USER_EMAIL=mark.shuttleworth@canonical.com`
- Verify that the Workload table appears and loads data

## Issue

Fixes https://github.com/canonical-web-and-design/workplace-engineering-squad/issues/101